### PR TITLE
Line of semi-colons not recognized as comment. (Basic Lisp)

### DIFF
--- a/coloring-types.lisp
+++ b/coloring-types.lisp
@@ -62,8 +62,7 @@
    ((:normal :first-char-on-line)
     ((scan #\()
      (set-mode :in-list
-               :until (scan #\)))))
-   (:first-char-on-line
+               :until (scan #\))))
     ((scan #\;)
      (set-mode :comment
                :until (scan #\newline)))


### PR DESCRIPTION
I noticed this on my blog: If I have block of comments like so:

```
;;;;;;;;;;;;;;;;;;;;;
;; semaphore class ;;
;;;;;;;;;;;;;;;;;;;;;
```

The first line of semi-colons wasn't being treated as a comment.
